### PR TITLE
aiofiles 25.1.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,24 +1,25 @@
 {% set name = "aiofiles" %}
-{% set version = "24.1.0" %}
+{% set version = "25.1.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 22a075c9e5a3810f0c2e48f3008c94d68c65d763b9b03857924c99e57355166c
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true # [py<38]
+  skip: true # [py<39]
 
 requirements:
   host:
     - python
     - pip
     - hatchling
+    - hatch-vcs
   run:
     - python
 
@@ -32,8 +33,8 @@ test:
     - pytest -v --asyncio-mode=auto tests
   requires:
     - pip
-    - pytest >=8.2.2
-    - pytest-asyncio >=0.23.7
+    - pytest >=8.3.5
+    - pytest-asyncio >=1.0.0
 
 about:
   home: https://github.com/Tinche/aiofiles


### PR DESCRIPTION
aiofiles 25.1.0 

**Destination channel:** Defaults

### Links

- [PKG-12631]
- dev_url:        https://github.com/Tinche/aiofiles/tree/v25.1.0
- conda_forge:    https://github.com/conda-forge/aiofiles-feedstock
- pypi:           https://pypi.org/project/aiofiles/25.1.0
- pypi inspector: https://inspector.pypi.io/project/aiofiles/25.1.0

### Explanation of changes:

- new version number


[PKG-12631]: https://anaconda.atlassian.net/browse/PKG-12631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ